### PR TITLE
Use ucs-2le for charset conversion

### DIFF
--- a/tests/cyrillic-transliterate.phpt
+++ b/tests/cyrillic-transliterate.phpt
@@ -5,12 +5,12 @@ Test for cyrillic transliterate filter
 $filters = array(
 	'cyrillic_transliterate', 'cyrillic_transliterate_bulgarian', 'cyrillic_lowercase'
 );
-$string = iconv("utf-8", "ucs-2", file_get_contents(__DIR__.'/cyrillic-transliterate.txt'));
+$string = iconv("utf-8", "ucs-2le", file_get_contents(__DIR__.'/cyrillic-transliterate.txt'));
 foreach ($filters as $filter) {
 	echo "============================\n";
 	echo "Running filter '$filter':\n\n";
 	$res = transliterate($string, array($filter));
-	echo iconv('ucs-2', 'utf-8', $res);
+	echo iconv('ucs-2le', 'utf-8', $res);
 }
 ?>
 --EXPECT--

--- a/tests/decompose.phpt
+++ b/tests/decompose.phpt
@@ -5,10 +5,10 @@ Test for decomposition filters
 $filters = array(
 	'decompose_special', 'decompose_currency_signs', 'decompose', 'normalize_numbers', 'normalize_superscript', 'normalize_subscript'
 );
-$string = iconv("utf-8", "ucs-2", file_get_contents(__DIR__.'/decompose.txt'));
+$string = iconv("utf-8", "ucs-2le", file_get_contents(__DIR__.'/decompose.txt'));
 
 $res = transliterate($string, $filters);
-echo iconv('ucs-2', 'utf-8', $res);
+echo iconv('ucs-2le', 'utf-8', $res);
 ?>
 --EXPECT--
 Decompose currency:

--- a/tests/greek-transliterate.phpt
+++ b/tests/greek-transliterate.phpt
@@ -5,12 +5,12 @@ Test for greek transliterate filter
 $filters = array(
 	'greek_transliterate', 'greek_lowercase'
 );
-$string = iconv("utf-8", "ucs-2", file_get_contents(__DIR__.'/greek-transliterate.txt'));
+$string = iconv("utf-8", "ucs-2le", file_get_contents(__DIR__.'/greek-transliterate.txt'));
 foreach ($filters as $filter) {
 	echo "============================\n";
 	echo "Running filter '$filter':\n\n";
 	$res = transliterate($string, array($filter));
-	echo iconv('ucs-2', 'utf-8', $res);
+	echo iconv('ucs-2le', 'utf-8', $res);
 }
 ?>
 --EXPECT--

--- a/tests/han-transliterate.phpt
+++ b/tests/han-transliterate.phpt
@@ -5,11 +5,11 @@ Test for han transliterate filter
 $filters = array(
 	'han_transliterate',
 );
-$string = iconv("utf-8", "ucs-2", file_get_contents(__DIR__.'/han-transliterate.txt'));
+$string = iconv("utf-8", "ucs-2le", file_get_contents(__DIR__.'/han-transliterate.txt'));
 foreach ($filters as $filter) {
 	echo "Running filter '$filter':\n\n";
 	$res = transliterate($string, array($filter));
-	echo iconv('ucs-2', 'utf-8', $res);
+	echo iconv('ucs-2le', 'utf-8', $res);
 }
 ?>
 --EXPECT--

--- a/tests/han-transliterate1.phpt
+++ b/tests/han-transliterate1.phpt
@@ -5,11 +5,11 @@ Test for han transliterate filter - 1
 $filters = array(
 	'han_transliterate',
 );
-$string = iconv("utf-8", "ucs-2", file_get_contents(__DIR__.'/han-transliterate1.txt'));
+$string = iconv("utf-8", "ucs-2le", file_get_contents(__DIR__.'/han-transliterate1.txt'));
 foreach ($filters as $filter) {
 	echo "Running filter '$filter':\n\n";
 	$res = transliterate($string, array($filter));
-	echo iconv('ucs-2', 'utf-8', $res);
+	echo iconv('ucs-2le', 'utf-8', $res);
 }
 ?>
 --EXPECT--

--- a/tests/hangul-to-jamo.phpt
+++ b/tests/hangul-to-jamo.phpt
@@ -5,9 +5,9 @@ Test for hangul to jamo conversion filter
 $filters = array(
 	'hangul_to_jamo', 'jamo_transliterate'
 );
-$string = iconv("utf-8", "ucs-2", file_get_contents(__DIR__.'/hangul-to-jamo.txt'));
+$string = iconv("utf-8", "ucs-2le", file_get_contents(__DIR__.'/hangul-to-jamo.txt'));
 $res = transliterate($string, $filters);
-echo iconv('ucs-2', 'utf-8', $res);
+echo iconv('ucs-2le', 'utf-8', $res);
 ?>
 --EXPECT--
 don Quijote nge ngosinkeosngeur hwanngyeonghapnita!

--- a/tests/hebrew-transliterate.phpt
+++ b/tests/hebrew-transliterate.phpt
@@ -5,11 +5,11 @@ Test for hebrew transliterate filter
 $filters = array(
 	'hebrew_transliterate',
 );
-$string = iconv("utf-8", "ucs-2", file_get_contents(__DIR__.'/hebrew-transliterate.txt'));
+$string = iconv("utf-8", "ucs-2le", file_get_contents(__DIR__.'/hebrew-transliterate.txt'));
 foreach ($filters as $filter) {
 	echo "Running filter '$filter':\n\n";
 	$res = transliterate($string, array($filter));
-	echo iconv('ucs-2', 'utf-8', $res);
+	echo iconv('ucs-2le', 'utf-8', $res);
 }
 ?>
 --EXPECT--

--- a/tests/latin-lowercase-001.phpt
+++ b/tests/latin-lowercase-001.phpt
@@ -5,9 +5,9 @@ Test for lowercasing latin filter
 $filters = array(
 	'latin_lowercase'
 );
-$string = iconv("utf-8", "ucs-2", file_get_contents(__DIR__.'/latin-lowercase.txt'));
+$string = iconv("utf-8", "ucs-2le", file_get_contents(__DIR__.'/latin-lowercase.txt'));
 $res = transliterate($string, $filters);
-echo iconv('ucs-2', 'utf-8', $res);
+echo iconv('ucs-2le', 'utf-8', $res);
 ?>
 --EXPECT--
 diacritical remove:

--- a/tests/normalize-ligature.phpt
+++ b/tests/normalize-ligature.phpt
@@ -5,11 +5,11 @@ Test for normalizing ligature filter
 $filters = array(
 	'normalize_ligature',
 );
-$string = iconv("utf-8", "ucs-2", file_get_contents(__DIR__.'/normalize-ligature.txt'));
+$string = iconv("utf-8", "ucs-2le", file_get_contents(__DIR__.'/normalize-ligature.txt'));
 foreach ($filters as $filter) {
 	echo "Running filter '$filter':\n\n";
 	$res = transliterate($string, array($filter));
-	echo iconv('ucs-2', 'utf-8', $res);
+	echo iconv('ucs-2le', 'utf-8', $res);
 }
 ?>
 --EXPECT--

--- a/tests/punctuation.phpt
+++ b/tests/punctuation.phpt
@@ -5,12 +5,12 @@ Test for punctuation ligature filter
 $filters = array(
 	'normalize_punctuation', 'remove_punctuation'
 );
-$string = iconv("utf-8", "ucs-2", file_get_contents(__DIR__.'/punctuation.txt'));
+$string = iconv("utf-8", "ucs-2le", file_get_contents(__DIR__.'/punctuation.txt'));
 foreach ($filters as $filter) {
 	echo "=================================\n";
 	echo "Running filter '$filter':\n\n";
 	$res = transliterate($string, array($filter));
-	echo iconv('ucs-2', 'utf-8', $res);
+	echo iconv('ucs-2le', 'utf-8', $res);
 }
 ?>
 --EXPECT--

--- a/tests/special-decompose.phpt
+++ b/tests/special-decompose.phpt
@@ -5,12 +5,12 @@ Test for special decomposition filters
 	$filters = array(
 		'decompose_special', 'decompose_currency_signs', 'decompose',
 	);
-	$string = iconv("utf-8", "ucs-2", file_get_contents(__DIR__.'/special_decompose.txt'));
+	$string = iconv("utf-8", "ucs-2le", file_get_contents(__DIR__.'/special_decompose.txt'));
 	foreach ($filters as $filter) {
 		echo "\n===================================================\n";
 		echo "Running filter '$filter':\n";
 		$res = transliterate($string, array($filter));
-		echo iconv('ucs-2', 'utf-8', $res);
+		echo iconv('ucs-2le', 'utf-8', $res);
 	}
 ?>
 --EXPECT--


### PR DESCRIPTION
Translit uses "ucs-2le" internally. When you don't specify endings, it might appear to be another option, which is actually happening on some versions of Mac OS. Changed charset in tests to make them pass.